### PR TITLE
Remove anything related to Istio namespace

### DIFF
--- a/namespaces/istio-system/namespace.yaml
+++ b/namespaces/istio-system/namespace.yaml
@@ -1,7 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: istio-system 
-  labels:
-    istio-injection: disabled
-


### PR DESCRIPTION
It gets created as part of installing Istio, so there is no point trying to add a small piece of it here.